### PR TITLE
Added TUD-FNG benchmark to the web-app

### DIFF
--- a/jadewa/resources/TUD-FNG.json
+++ b/jadewa/resources/TUD-FNG.json
@@ -1,0 +1,81 @@
+{
+    "general": {
+        "tally_options_labels": [
+            "Shielding depth",
+            "Tally"
+        ],
+        "generic_tallies": true
+    },
+    "504": {
+        "tally_name": "41.5 cm - Neutron fluence",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron fluence [1/MeV/cm^2/n]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron fluence [1/MeV/cm^2/n]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_per_unit_bin": "Energy"
+    },
+    "514": {
+        "tally_name": "41.5 cm - Photon fluence",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Photon fluence [1/MeV/cm^2/n]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Photon fluence [1/MeV/cm^2/n]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_per_unit_bin": "Energy"
+    },
+    "524": {
+        "tally_name": "87.6 cm - Neutron fluence",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron fluence [1/MeV/cm^2/n]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron fluence [1/MeV/cm^2/n]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_per_unit_bin": "Energy"
+    },
+    "534": {
+        "tally_name": "87.6 cm - Photon fluence",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Photon fluence [1/MeV/cm^2/n]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Photon fluence [1/MeV/cm^2/n]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_per_unit_bin": "Energy"
+    }
+}


### PR DESCRIPTION
# Description

Added the TUD-FNG .json file. No additional dependencies were introduced and no new functionalities/corrections needed to be added/applied to the rest of the code.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a change in the web DB structure

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run the web-app locally. Find attached the obtained plots below.
- Run all the test functions available.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%

# Example plots:
<img width="880" alt="504" src="https://github.com/user-attachments/assets/1654c5c4-d321-40af-83ad-ec6a6840451c">

Even though the different libraries seem to contain the same values in the previous plot, they are not. I have checked the raw data files and they are very similar, but not equal. If certain parts of the plot are zoomed in, this is also visible.


<img width="883" alt="514" src="https://github.com/user-attachments/assets/5cf509e4-8e4d-460d-891c-4997d3df77f6">
<img width="882" alt="524" src="https://github.com/user-attachments/assets/10c1e16c-bc8c-41c7-a892-3d63de6689e3">
<img width="883" alt="534" src="https://github.com/user-attachments/assets/6022bc0b-3393-4461-85de-bd13dfd53f34">
