### PR TITLE
Addition of of the FNG-SS, FNG-HCPB, FNG-SiC, ASPIS-PCA-Replica_flux and ASPIS-PCA-Replica_RR benchmarks to the Web-App

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -22,7 +22,7 @@ from jadewa.utils import (
 # Get list of CSV files in current directory
 OWNER = "JADE-V-V"
 REPO = "JADE-RAW-RESULTS"
-BRANCH = "add_FNG+ASPIS"
+BRANCH = "main"
 
 
 # Initialize status and processor

--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -231,9 +231,7 @@ def _recursive_select_split_option(columns, ctg_dict, labels, selections=None):
             label = 0
 
         option_selected = st.selectbox(
-            label,
-            options_available,
-            index=index,
+            label="", options=options_available, index=index, key=label
         )
 
         # add selection to the list
@@ -269,7 +267,7 @@ def _get_split_selection(
             label = 0
         elif isinstance(labels, str):
             label = labels
-            labels = [label] + [""] * (max_depth - 1)
+            labels = [label] + [f"{label}_{i+1}" for i in range(max_depth - 1)]
         else:
             raise ValueError("There is a problem with the selection labels")
 

--- a/jadewa/resources/ASPIS-PCA-Replica_RR.json
+++ b/jadewa/resources/ASPIS-PCA-Replica_RR.json
@@ -1,0 +1,109 @@
+{
+    "In 4": {
+        "tally_name": "Reaction Rates - In115 (n,n') In115m",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "Input 1",
+                "Input 2",
+                "1078"
+            ],
+            "ticktext": [
+                39.01,
+                49.61,
+                58.61
+            ]
+        },
+        "only_ratio": true
+    },
+    "Rh 4": {
+        "tally_name": "Reaction Rates - Rh103 (n,n') Rh103m",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "Input 1",
+                "924",
+                "944",
+                "Input 4",
+                "Input 5",
+                "Input 6",
+                "Input 7",
+                "Input 8",
+                "Input 9",
+                "1078"
+            ],
+            "ticktext": [
+                1.91,
+                7.41,
+                12.41,
+                14.01,
+                19.91,
+                25.41,
+                30.41,
+                39.01,
+                49.61,
+                58.61
+            ]
+        },
+        "only_ratio": true
+    },
+    "S 4": {
+        "tally_name": "Reaction Rates - S32 (n,p) P32",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "Input 1",
+                "Input 2",
+                "1078"
+            ],
+            "ticktext": [
+                39.01,
+                49.61,
+                58.61
+            ]
+        },
+        "only_ratio": true
+    }
+}

--- a/jadewa/resources/ASPIS-PCA-Replica_flux.json
+++ b/jadewa/resources/ASPIS-PCA-Replica_flux.json
@@ -1,0 +1,44 @@
+{
+    "general": {
+        "tally_options_labels": [
+            "Tally",
+            "Shielding thickness"
+        ]
+    },
+    "spectra 914": {
+        "tally_name": "Neutron Spectra - z = 39.01cm",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Spectrum [Flux/lethargy/NESTOR Watt]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Spectrum [Flux/lethargy/NESTOR Watt]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_lethargy": true
+    },
+    "spectra 924": {
+        "tally_name": "Neutron Spectra - z = 58.61cm",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Spectrum [Flux/lethargy/NESTOR Watt]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Spectrum [Flux/lethargy/NESTOR Watt]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "compute_lethargy": true
+    }
+}

--- a/jadewa/resources/FNG-HCPB.json
+++ b/jadewa/resources/FNG-HCPB.json
@@ -1,0 +1,396 @@
+{
+    "Al 4": {
+        "tally_name": "Reaction Rates - Al27 (n,a) Na24",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "48001.0",
+                "48002.0",
+                "48003.0",
+                "48004.0"
+            ],
+            "ticktext": [
+                4.10115,
+                10.40115,
+                16.70115,
+                23.00115
+            ]
+        },
+        "only_ratio": true
+    },
+    "Au 4": {
+        "tally_name": "Reaction Rates - Au197 (n,g) Au198",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "38001.0",
+                "38002.0",
+                "38003.0",
+                "38004.0"
+            ],
+            "ticktext": [
+                4.055,
+                10.355,
+                16.655,
+                22.955
+            ]
+        },
+        "only_ratio": true
+    },
+    "Nb 4": {
+        "tally_name": "Reaction Rates - Nb93 (n,2n) Nb92",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "28000.0",
+                "28001.0",
+                "28002.0",
+                "28003.0",
+                "28004.0"
+            ],
+            "ticktext": [
+                0,
+                4.055,
+                10.355,
+                16.655,
+                22.955
+            ]
+        },
+        "only_ratio": true
+    },
+    "Ni 4": {
+        "tally_name": "Reaction Rates - Ni58 (n,p) Co58",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "58001.0",
+                "58002.0",
+                "58003.0",
+                "58004.0"
+            ],
+            "ticktext": [
+                4.152,
+                10.452,
+                16.752,
+                23.052
+            ]
+        },
+        "only_ratio": true
+    },
+    "H3 84 ENEA2": {
+        "tally_name": "Tritium Activity - ENEA2",
+        "substitutions": {
+            "Cells": "Pellet n°",
+            "Value": "Activity [Bq/g]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Pellet n°",
+            "y": "Activity [Bq/g]",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "16016.0",
+                "16020.0",
+                "16024.0",
+                "16028.0",
+                "16032.0",
+                "16036.0",
+                "16040.0",
+                "16044.0",
+                "16048.0",
+                "16052.0",
+                "16056.0",
+                "16060.0"
+            ],
+            "ticktext": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+            ]
+        },
+        "subset": [
+            "Cells",
+            [
+                "16016.0",
+                "16020.0",
+                "16024.0",
+                "16028.0",
+                "16032.0",
+                "16036.0",
+                "16040.0",
+                "16044.0",
+                "16048.0",
+                "16052.0",
+                "16056.0",
+                "16060.0"
+            ]
+        ]
+    },
+    "H3 84 ENEA4": {
+        "tally_name": "Tritium Activity - ENEA4",
+        "substitutions": {
+            "Cells": "Pellet n°",
+            "Value": "Activity [Bq/g]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Pellet n°",
+            "y": "Activity [Bq/g]",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "16017.0",
+                "16021.0",
+                "16025.0",
+                "16029.0",
+                "16033.0",
+                "16037.0",
+                "16041.0",
+                "16045.0",
+                "16049.0",
+                "16053.0",
+                "16057.0",
+                "16061.0"
+            ],
+            "ticktext": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+            ]
+        },
+        "subset": [
+            "Cells",
+            [
+                "16017.0",
+                "16021.0",
+                "16025.0",
+                "16029.0",
+                "16033.0",
+                "16037.0",
+                "16041.0",
+                "16045.0",
+                "16049.0",
+                "16053.0",
+                "16057.0",
+                "16061.0"
+            ]
+        ]
+    },
+    "H3 84 ENEA6": {
+        "tally_name": "Tritium Activity - ENEA6",
+        "substitutions": {
+            "Cells": "Pellet n°",
+            "Value": "Activity [Bq/g]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Pellet n°",
+            "y": "Activity [Bq/g]",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "16018.0",
+                "16022.0",
+                "16026.0",
+                "16030.0",
+                "16034.0",
+                "16038.0",
+                "16042.0",
+                "16046.0",
+                "16050.0",
+                "16054.0",
+                "16058.0",
+                "16062.0"
+            ],
+            "ticktext": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+            ]
+        },
+        "subset": [
+            "Cells",
+            [
+                "16018.0",
+                "16022.0",
+                "16026.0",
+                "16030.0",
+                "16034.0",
+                "16038.0",
+                "16042.0",
+                "16046.0",
+                "16050.0",
+                "16054.0",
+                "16058.0",
+                "16062.0"
+            ]
+        ]
+    },
+    "H3 84 ENEA8": {
+        "tally_name": "Tritium Activity - ENEA8",
+        "substitutions": {
+            "Cells": "Pellet n°",
+            "Value": "Activity [Bq/g]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Pellet n°",
+            "y": "Activity [Bq/g]",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "16019.0",
+                "16023.0",
+                "16027.0",
+                "16031.0",
+                "16035.0",
+                "16039.0",
+                "16043.0",
+                "16047.0",
+                "16051.0",
+                "16055.0",
+                "16059.0",
+                "16063.0"
+            ],
+            "ticktext": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12
+            ]
+        },
+        "subset": [
+            "Cells",
+            [
+                "16019.0",
+                "16023.0",
+                "16027.0",
+                "16031.0",
+                "16035.0",
+                "16039.0",
+                "16043.0",
+                "16047.0",
+                "16051.0",
+                "16055.0",
+                "16059.0",
+                "16063.0"
+            ]
+        ]
+    }
+}

--- a/jadewa/resources/FNG-SS.json
+++ b/jadewa/resources/FNG-SS.json
@@ -1,0 +1,269 @@
+{
+    "Al 4": {
+        "tally_name": "Reaction Rates - Al27 (n,a) Na24",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                4.95,
+                10.05,
+                20.15,
+                30.30,
+                40.50,
+                50.70,
+                55.90
+            ]
+        },
+        "only_ratio": true
+    },
+    "Au 4": {
+        "tally_name": "Reaction Rates - Au197 (n,g) Au198",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                5.0,
+                10.0,
+                20.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0
+            ]
+        },
+        "only_ratio": true
+    },
+    "In 4": {
+        "tally_name": "Reaction Rates - In115 (n,n') In115m",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                4.95,
+                10.05,
+                20.15,
+                30.30,
+                40.50,
+                50.60,
+                60.90
+            ]
+        },
+        "only_ratio": true
+    },
+    "Mn 4": {
+        "tally_name": "Reaction Rates - Mn55 (n,g) Mn56",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                5.0,
+                10.0,
+                20.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0
+            ]
+        },
+        "only_ratio": true
+    },
+    "Ni-np 4": {
+        "tally_name": "Reaction Rates - Ni58 (n,p) Co58",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                4.95,
+                10.05,
+                20.15,
+                30.30,
+                40.50,
+                50.70,
+                60.90
+            ]
+        },
+        "only_ratio": true
+    },
+    "Ni-n2n 4": {
+        "tally_name": "Reaction Rates - Ni58 (n,2n) Ni57",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503"
+            ],
+            "ticktext": [
+                4.95,
+                10.05,
+                20.15,
+                30.30
+            ]
+        },
+        "only_ratio": true
+    },
+    "Fe 4": {
+        "tally_name": "Reaction Rates - Fe56 (n,p) Mn56",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "506"
+            ],
+            "ticktext": [
+                4.95,
+                10.05,
+                20.15,
+                30.30,
+                40.50,
+                50.70,
+                60.90
+            ]
+        },
+        "only_ratio": true
+    }
+}

--- a/jadewa/resources/FNG-SiC.json
+++ b/jadewa/resources/FNG-SiC.json
@@ -1,0 +1,167 @@
+{
+    "Al 4": {
+        "tally_name": "Reaction Rates - Al27 (n,a) Na24",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "602",
+                "612",
+                "622",
+                "632"
+            ],
+            "ticktext": [
+                10.41,
+                25.65,
+                40.89,
+                56.13
+            ]
+        },
+        "only_ratio": true
+    },
+    "Au 4": {
+        "tally_name": "Reaction Rates - Au197 (n,g) Au198",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "602",
+                "612",
+                "622",
+                "632"
+            ],
+            "ticktext": [
+                10.41,
+                25.65,
+                40.89,
+                56.13
+            ]
+        },
+        "only_ratio": true
+    },
+    "Ni 4": {
+        "tally_name": "Reaction Rates - Ni58 (n,p) Co58",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "602",
+                "612",
+                "622",
+                "632"
+            ],
+            "ticktext": [
+                10.41,
+                25.65,
+                40.89,
+                56.13
+            ]
+        },
+        "only_ratio": true
+    },
+    "Nb 4": {
+        "tally_name": "Reaction Rates - Nb93 (n,2n) Nb92",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "602",
+                "612",
+                "622",
+                "632"
+            ],
+            "ticktext": [
+                10.41,
+                25.65,
+                40.89,
+                56.13
+            ]
+        },
+        "only_ratio": true
+    },
+    "TLD 6": {
+        "tally_name": "Nuclear Heating (TLDs)",
+        "substitutions": {
+            "Cells": "Shielding thickness [cm]",
+            "Value": "C/E"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Shielding thickness [cm]",
+            "y": "C/E",
+            "log_x": false,
+            "log_y": false
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        },
+        "x_axis_format": {
+            "tickmode": "array",
+            "tickvals": [
+                "602",
+                "612",
+                "622",
+                "632"
+            ],
+            "ticktext": [
+                14.99,
+                30.23,
+                45.47,
+                60.71
+            ]
+        },
+        "only_ratio": true
+    }
+}

--- a/jadewa/utils.py
+++ b/jadewa/utils.py
@@ -272,6 +272,11 @@ def safe_add_ctg_to_dict(dictionary: dict, keys: list[str], value: str) -> dict:
     # update the dict definition
     if key not in dictionary:
         dictionary[key] = {}
+    # if the key already exists in the dictionary but its value is a list,
+    # we convert its value to a dictionary
+    elif isinstance(dictionary[key], list):
+        dictionary[key] = {
+            dictionary[key][i]: ["N.A."] for i in range(len(dictionary[key]))
+        }
 
-    dictionary = dictionary[key]
-    safe_add_ctg_to_dict(dictionary, keys[1:], value)
+    safe_add_ctg_to_dict(dictionary[key], keys[1:], value)

--- a/tests/app_streamlit_test.py
+++ b/tests/app_streamlit_test.py
@@ -65,6 +65,14 @@ class TestStreamlitApp:
             "Neutron Flux at the external surface in Vitamin-J 175 energy groups"
         ).run()
 
+        # Test a benchmark that requires the selection of multiple selectboxes.
+        app.selectbox(key="benchmark").select("ASPIS").run()
+        assert app.selectbox(key="benchmark").value == "ASPIS"
+        app.selectbox(key="benchmark_1").select("PCA").run()
+        assert app.selectbox(key="benchmark_1").value == "PCA"
+        app.selectbox(key="benchmark_2").select("Replica_flux").run()
+        assert app.selectbox(key="benchmark_2").value == "Replica_flux"
+
         # Test the library checkboxes by selecting and deselecting one and
         # checking if it matches the expected bool values.
         app.checkbox(key="JEFF 3.3").check().run()

--- a/tests/app_streamlit_test.py
+++ b/tests/app_streamlit_test.py
@@ -1,5 +1,7 @@
 from streamlit.testing.v1 import AppTest
 
+from app_streamlit import _recursive_assign_na_option
+
 
 class TestStreamlitApp:
     """Test the Streamlit app. Better to reunite all tests in one class to avoid
@@ -65,13 +67,11 @@ class TestStreamlitApp:
             "Neutron Flux at the external surface in Vitamin-J 175 energy groups"
         ).run()
 
-        # Test a benchmark that requires the selection of multiple selectboxes.
+        # Test a benchmark that requires the selection of more than one selectbox.
         app.selectbox(key="benchmark").select("ASPIS").run()
         assert app.selectbox(key="benchmark").value == "ASPIS"
-        app.selectbox(key="benchmark_1").select("PCA").run()
-        assert app.selectbox(key="benchmark_1").value == "PCA"
-        app.selectbox(key="benchmark_2").select("Replica_flux").run()
-        assert app.selectbox(key="benchmark_2").value == "Replica_flux"
+        app.selectbox(key="benchmark_1").select("Fe88").run()
+        assert app.selectbox(key="benchmark_1").value == "Fe88"
 
         # Test the library checkboxes by selecting and deselecting one and
         # checking if it matches the expected bool values.
@@ -79,3 +79,11 @@ class TestStreamlitApp:
         assert app.checkbox(key="JEFF 3.3").value is True
         app.checkbox(key="JEFF 3.3").uncheck().run()
         assert app.checkbox(key="JEFF 3.3").value is False
+
+        # Check the correct functioning of the _recursive_assign_na_option function
+        dict_test = _recursive_assign_na_option(
+            {"benchmark": {"benchmark_1": {"benchmark_2": ["benchmark_3"]}}}
+        )
+        assert dict_test == {
+            "benchmark": {"benchmark_1": {"benchmark_2": {"benchmark_3": ["N.A."]}}}
+        }


### PR DESCRIPTION
# Description

This pull request contains the .json files necessary to include the FNG-SS, FNG-HCPB, FNG-SiC, ASPIS-PCA-Replica_flux and ASPIS-PCA-Replica_RR benchmarks to the Web-App. Screenshots containing some examples have been added at the end of this pull request, at the section "Example screenshots".

Additionally, a few modifications were applied to the "jadewa/utils.py" and the "app_streamlit.py" files. The motive behind these modifications was to add a feature: support different lengths of successive option selections for a given initial selected option. Let's briefly analyze an example to understand this feature better: One of the benchmarks which was already implemented is "ASPIS-Fe88" and a new one that we wanted to implement with this pull request is "ASPIS-PCA-Replica_flux". While to select "ASPIS-Fe88" only 2 successive selectboxes are needed (one for "ASPIS" and the other one for "Fe88"), for "ASPIS-PCA-Replica_flux" we need 3 successive selectboxes (one for "ASPIS", another one for "PCA" and a third one to select "Replica_flux"). Before this pull request, the coexistence of both of these names ("ASPIS-Fe88" and "ASPIS-PCA-Replica_flux") would not have been possible, as they share the initial part "ASPIS" (therefore, the option selected in the first selectbox is the same for both of them) but they have a different length in the successive selections needed to select their full name.

Also, as a consequence of the addition of the feature described in the previous paragraph, the selectboxes containing only the option "N.A." are no longer visible in the Web-App.

No additional dependencies are introduced.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a change in the web DB structure

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- All of the already existing tests were run and passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%

# Example screenshots:

FNG-SiC, Nuclear Heating (TLDs):
![image](https://github.com/user-attachments/assets/0baf8473-82fe-4ad9-9374-1f2f54e50967)

FNG-HCPB, Tritium Activity, ENEA4:
![image](https://github.com/user-attachments/assets/169a46f0-5dcd-43a1-8806-33e0a3bf16aa)

FNG-SS, Reaction Rates, Fe56 (n,p) Mn56:
![image](https://github.com/user-attachments/assets/bcb08250-40dc-4094-8764-e61eb5442515)

ASPIS-PCA-Replica_flux, Neutron Spectra, z=39.01cm:
![image](https://github.com/user-attachments/assets/4fa41c0e-c7bf-4310-a356-f28c7de78634)


