### PR TITLE
Fix TUD-W json + update deprecated parameter

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -120,13 +120,13 @@ def display_metadata(
     pivot_no_sddr: pd.DataFrame, pivot_sddr: pd.DataFrame, sorted_df: pd.DataFrame
 ) -> None:
     st.header("Available simulations (no activation)")
-    st.dataframe(pivot_no_sddr, use_container_width=True)
+    st.dataframe(pivot_no_sddr, width="stretch")
 
     st.header("Available simulations (activation)")
-    st.dataframe(pivot_sddr, use_container_width=True)
+    st.dataframe(pivot_sddr, width="stretch")
 
     st.header("Complete metadata on available simulations")
-    st.dataframe(sorted_df, use_container_width=True)
+    st.dataframe(sorted_df, width="stretch")
 
 
 def _split_options(
@@ -422,7 +422,7 @@ def main():
                 fig = None
 
             if fig:
-                plotly_chart = st.plotly_chart(fig, use_container_width=True)
+                plotly_chart = st.plotly_chart(fig, width="stretch")
 
             expander = st.expander(
                 "Select specific libraries across benchmarks.",

--- a/jadewa/resources/TUD-W.json
+++ b/jadewa/resources/TUD-W.json
@@ -6,7 +6,7 @@
         ]
     },
     "5 cm - Neutron flux": {
-        "result": "TUD-W_pos1 Neutron flux",
+        "result": "TUD-W_pos1 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Neutron flux [1/MeV/n/cm^2]"
@@ -23,7 +23,7 @@
         }
     },
     "5 cm - Photon flux": {
-        "result": "TUD-W_pos1 Photon flux",
+        "result": "TUD-W_pos1 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Photon flux [1/MeV/n/cm^2]"
@@ -40,7 +40,7 @@
         }
     },
     "15 cm - Neutron flux": {
-        "result": "TUD-W_pos2 Neutron flux",
+        "result": "TUD-W_pos2 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Neutron flux [1/MeV/n/cm^2]"
@@ -57,7 +57,7 @@
         }
     },
     "15 cm - Photon flux": {
-        "result": "TUD-W_pos2 Photon flux",
+        "result": "TUD-W_pos2 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Photon flux [1/MeV/n/cm^2]"
@@ -74,7 +74,7 @@
         }
     },
     "25 cm - Neutron flux": {
-        "result": "TUD-W_pos3 Neutron flux",
+        "result": "TUD-W_pos3 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Neutron flux [1/MeV/n/cm^2]"
@@ -91,7 +91,7 @@
         }
     },
     "25 cm - Photon flux": {
-        "result": "TUD-W_pos3 Photon flux",
+        "result": "TUD-W_pos3 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Photon flux [1/MeV/n/cm^2]"
@@ -108,7 +108,7 @@
         }
     },
     "35 cm - Neutron flux": {
-        "result": "TUD-W_pos4 Neutron flux",
+        "result": "TUD-W_pos4 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Neutron flux [1/MeV/n/cm^2]"
@@ -125,7 +125,7 @@
         }
     },
     "35 cm - Photon flux": {
-        "result": "TUD-W_pos4 Photon flux",
+        "result": "TUD-W_pos4 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
             "Value": "Photon flux [1/MeV/n/cm^2]"

--- a/jadewa/resources/TUD-W.json
+++ b/jadewa/resources/TUD-W.json
@@ -9,12 +9,12 @@
         "result": "TUD-W_pos1 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Neutron flux [1/MeV/n/cm^2]"
+            "Value": "Neutron flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Neutron flux [1/MeV/n/cm^2]",
+            "y": "Neutron flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -26,12 +26,12 @@
         "result": "TUD-W_pos1 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Photon flux [1/MeV/n/cm^2]"
+            "Value": "Photon flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Photon flux [1/MeV/n/cm^2]",
+            "y": "Photon flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -43,12 +43,12 @@
         "result": "TUD-W_pos2 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Neutron flux [1/MeV/n/cm^2]"
+            "Value": "Neutron flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Neutron flux [1/MeV/n/cm^2]",
+            "y": "Neutron flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -60,12 +60,12 @@
         "result": "TUD-W_pos2 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Photon flux [1/MeV/n/cm^2]"
+            "Value": "Photon flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Photon flux [1/MeV/n/cm^2]",
+            "y": "Photon flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -77,12 +77,12 @@
         "result": "TUD-W_pos3 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Neutron flux [1/MeV/n/cm^2]"
+            "Value": "Neutron flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Neutron flux [1/MeV/n/cm^2]",
+            "y": "Neutron flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -94,12 +94,12 @@
         "result": "TUD-W_pos3 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Photon flux [1/MeV/n/cm^2]"
+            "Value": "Photon flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Photon flux [1/MeV/n/cm^2]",
+            "y": "Photon flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -111,12 +111,12 @@
         "result": "TUD-W_pos4 Neutron spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Neutron flux [1/MeV/n/cm^2]"
+            "Value": "Neutron flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Neutron flux [1/MeV/n/cm^2]",
+            "y": "Neutron flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },
@@ -128,12 +128,12 @@
         "result": "TUD-W_pos4 Photon spectra",
         "substitutions": {
             "Energy": "Energy [MeV]",
-            "Value": "Photon flux [1/MeV/n/cm^2]"
+            "Value": "Photon flux [1/MeV/n/cm²]"
         },
         "plot_type": "step",
         "plot_args": {
             "x": "Energy [MeV]",
-            "y": "Photon flux [1/MeV/n/cm^2]",
+            "y": "Photon flux [1/MeV/n/cm²]",
             "log_x": true,
             "log_y": false
         },

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -23,9 +23,7 @@ class TestProcessor:
     @pytest.fixture
     def processor_github(self):
         """Fixture for github processor"""
-        return Processor(
-            Status.from_github()
-        )
+        return Processor(Status.from_github())
 
     @pytest.fixture
     def processor(self, status: Status):
@@ -134,16 +132,14 @@ class TestProcessor:
 
     def test_get_graph_data_github(self):
         """Test the get_graph_data method with github data"""
-        processor = Processor(
-            Status.from_github()
-        )
+        processor = Processor(Status.from_github())
         data = processor._get_graph_data(
             "Sphere",
             "FENDL 3.2c",
             "1001_H-1 - Neutron Flux at the external surface in Vitamin-J 175 energy groups",
         )
         assert len(data.columns) == 4
-        assert len(set(data["Neutron flux [n/cm^2/s]"].to_list())) == 1006
+        assert len(set(data["Neutron flux [n/cm^2/s]"].to_list())) == 1174
 
         data = processor._get_graph_data(
             "C-Model",


### PR DESCRIPTION
# Description

This pull request includes the following modifications:
- Update of the .csv names in the TUD-W _json_ file. Instead of "Neutron spectra" and "Photon spectra", the .json file was pointing to .csv files named after "Neutron flux" and "Photon flux". This has been fixed, which closes issue #38 .
- Improvement of the TUD-W y-axis labels.
- Update of a deprecated parameter. When using _use_container_width_ instead of _width_, the following warning was raised:
<img width="605" height="65" alt="image" src="https://github.com/user-attachments/assets/4d0ce093-a8af-4276-a097-e898fb59f24c" />

I simply applied the suggested update by the warning and double checked that this didn't affect anything else.

Fixes #38 . No additional dependencies were introduced.

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a change in the web DB structure

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run the WebApp locally to ensure that TUD-W csv files are now correctly fetched.
- Run the WebApp test suite. All tests passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%