### PR TITLE
Addition of the ALARM-CF-LAB benchmark

### DIFF
--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -224,7 +224,11 @@ def _recursive_select_split_option(columns, ctg_dict, labels, selections=None):
         unique_key = f"{label}_{path_key}"
 
         option_selected = st.selectbox(
-            label=label, options=options_available, index=index, key=unique_key
+            label=label if label else " ",
+            options=options_available,
+            index=index,
+            key=unique_key,
+            label_visibility="hidden" if not label else "visible",
         )
         # add selection to the list
         selections.append(option_selected)

--- a/jadewa/resources/ALARM-CF-LAB.json
+++ b/jadewa/resources/ALARM-CF-LAB.json
@@ -194,12 +194,12 @@
         "result": "Count rates 2 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -207,12 +207,12 @@
         "result": "Count rates 3 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -220,12 +220,12 @@
         "result": "Count rates 5 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -233,12 +233,12 @@
         "result": "Count rates 5 inches (without Cd)",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -246,12 +246,12 @@
         "result": "Count rates 8 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -259,12 +259,12 @@
         "result": "Count rates 10 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     },
@@ -272,12 +272,12 @@
         "result": "Count rates 12 inches",
         "substitutions": {
             "Cells": "Detector position",
-            "Value": "Neutron count rate [n/s]"
+            "Value": "Neutron count rate [pulses/s]"
         },
         "plot_type": "scatter",
         "plot_args": {
             "x": "Detector position",
-            "y": "Neutron count rate [n/s]"
+            "y": "Neutron count rate [pulses/s]"
         },
         "only_ratio": true
     }

--- a/jadewa/resources/ALARM-CF-LAB.json
+++ b/jadewa/resources/ALARM-CF-LAB.json
@@ -1,0 +1,284 @@
+{
+    "general": {
+        "tally_options_labels": [
+            "Labyrinth configuration",
+            "Tally",
+            "Detector position"
+        ],
+        "generic_tallies": true
+    },
+    "{} - Total neutron flux": {
+        "result": "Total neutron flux",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron flux [n/cm²]"
+        },
+        "only_ratio": true
+    },
+    "{} - Neutron spectra - 1": {
+        "result": "Neutron spectra (pos 1)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 2": {
+        "result": "Neutron spectra (pos 2)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 3": {
+        "result": "Neutron spectra (pos 3)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 4": {
+        "result": "Neutron spectra (pos 4)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 5": {
+        "result": "Neutron spectra (pos 5)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 6": {
+        "result": "Neutron spectra (pos 6)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 7": {
+        "result": "Neutron spectra (pos 7)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 8": {
+        "result": "Neutron spectra (pos 8)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 9": {
+        "result": "Neutron spectra (pos 9)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Neutron spectra - 10": {
+        "result": "Neutron spectra (pos 10)",
+        "substitutions": {
+            "Energy": "Energy [MeV]",
+            "Value": "Neutron flux [n/cm²]"
+        },
+        "plot_type": "step",
+        "plot_args": {
+            "x": "Energy [MeV]",
+            "y": "Neutron flux [n/cm²]",
+            "log_x": true,
+            "log_y": true
+        },
+        "y_axis_format": {
+            "tickformat": ".2e"
+        }
+    },
+    "{} - Count rates 2\"": {
+        "result": "Count rates 2 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 3\"": {
+        "result": "Count rates 3 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 5\"": {
+        "result": "Count rates 5 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 5\" (no Cd)": {
+        "result": "Count rates 5 inches (without Cd)",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 8\"": {
+        "result": "Count rates 8 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 10\"": {
+        "result": "Count rates 10 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    },
+    "{} - Count rates 12\"": {
+        "result": "Count rates 12 inches",
+        "substitutions": {
+            "Cells": "Detector position",
+            "Value": "Neutron count rate [n/s]"
+        },
+        "plot_type": "scatter",
+        "plot_args": {
+            "x": "Detector position",
+            "y": "Neutron count rate [n/s]"
+        },
+        "only_ratio": true
+    }
+}

--- a/jadewa/resources/ALARM-CF-LAB.json
+++ b/jadewa/resources/ALARM-CF-LAB.json
@@ -1,9 +1,9 @@
 {
     "general": {
         "tally_options_labels": [
-            "Labyrinth configuration",
+            "labyrinth configuration",
             "Tally",
-            "Detector position"
+            ""
         ],
         "generic_tallies": true
     },
@@ -20,7 +20,7 @@
         },
         "only_ratio": true
     },
-    "{} - Neutron spectra - 1": {
+    "{} - Neutron spectra - Detector position 1": {
         "result": "Neutron spectra (pos 1)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -37,7 +37,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 2": {
+    "{} - Neutron spectra - Detector position 2": {
         "result": "Neutron spectra (pos 2)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -54,7 +54,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 3": {
+    "{} - Neutron spectra - Detector position 3": {
         "result": "Neutron spectra (pos 3)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -71,7 +71,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 4": {
+    "{} - Neutron spectra - Detector position 4": {
         "result": "Neutron spectra (pos 4)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -88,7 +88,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 5": {
+    "{} - Neutron spectra - Detector position 5": {
         "result": "Neutron spectra (pos 5)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -105,7 +105,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 6": {
+    "{} - Neutron spectra - Detector position 6": {
         "result": "Neutron spectra (pos 6)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -122,7 +122,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 7": {
+    "{} - Neutron spectra - Detector position 7": {
         "result": "Neutron spectra (pos 7)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -139,7 +139,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 8": {
+    "{} - Neutron spectra - Detector position 8": {
         "result": "Neutron spectra (pos 8)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -156,7 +156,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 9": {
+    "{} - Neutron spectra - Detector position 9": {
         "result": "Neutron spectra (pos 9)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -173,7 +173,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Neutron spectra - 10": {
+    "{} - Neutron spectra - Detector position 10": {
         "result": "Neutron spectra (pos 10)",
         "substitutions": {
             "Energy": "Energy [MeV]",
@@ -190,7 +190,7 @@
             "tickformat": ".2e"
         }
     },
-    "{} - Count rates 2\"": {
+    "{} - Count rates - Bonner spheres 2\"": {
         "result": "Count rates 2 inches",
         "substitutions": {
             "Cells": "Detector position",
@@ -203,7 +203,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 3\"": {
+    "{} - Count rates - Bonner spheres 3\"": {
         "result": "Count rates 3 inches",
         "substitutions": {
             "Cells": "Detector position",
@@ -216,7 +216,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 5\"": {
+    "{} - Count rates - Bonner spheres 5\"": {
         "result": "Count rates 5 inches",
         "substitutions": {
             "Cells": "Detector position",
@@ -229,7 +229,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 5\" (no Cd)": {
+    "{} - Count rates - Bonner spheres 5\" (no Cd)": {
         "result": "Count rates 5 inches (without Cd)",
         "substitutions": {
             "Cells": "Detector position",
@@ -242,7 +242,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 8\"": {
+    "{} - Count rates - Bonner spheres 8\"": {
         "result": "Count rates 8 inches",
         "substitutions": {
             "Cells": "Detector position",
@@ -255,7 +255,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 10\"": {
+    "{} - Count rates - Bonner spheres 10\"": {
         "result": "Count rates 10 inches",
         "substitutions": {
             "Cells": "Detector position",
@@ -268,7 +268,7 @@
         },
         "only_ratio": true
     },
-    "{} - Count rates 12\"": {
+    "{} - Count rates - Bonner spheres 12\"": {
         "result": "Count rates 12 inches",
         "substitutions": {
             "Cells": "Detector position",

--- a/tests/processor_test.py
+++ b/tests/processor_test.py
@@ -139,7 +139,7 @@ class TestProcessor:
             "1001_H-1 - Neutron Flux at the external surface in Vitamin-J 175 energy groups",
         )
         assert len(data.columns) == 4
-        assert len(set(data["Neutron flux [n/cm^2/s]"].to_list())) == 1174
+        assert len(set(data["Neutron flux [n/cm^2/s]"].to_list())) == 1342
 
         data = processor._get_graph_data(
             "C-Model",


### PR DESCRIPTION
# Description

This pull request includes the addition of the ALARM-CF-LAB experimental benchmark to JADE's WebApp. The corresponding .json file has been added.

Additionally, two additional modifications have been implemented:
- Fix to the _test_get_graph_data_github_ test function in _processor_test.py_
- Update of the __recursive__select_split_option_ function in _app_streamlit.py_ to avoid a large non-breaking warning raised in relation to missing labels for the WebApp dropdown menus.

No additional dependencies were introduced.

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a change in the web DB structure

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran all tests in the JADE WebApp test suite locally. After a minor fix on the _test_get_graph_data_github_ test function, all passed. 
- Ran the WebApp locally to verify the correct implementation of the ALARM-CF-LAB benchmark.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%